### PR TITLE
fix: ajustado parâmetro da função upload

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,8 +101,14 @@ func exemploUpload(client *s3handler.Client) {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
+	file, err := os.Open("/home/angelo/Testes/exemplo.html")
+	if err != nil {
+		log.Printf("Erro ao fazer upload: %s", err.Error())
+	}
+	defer file.Close()
+
 	log.Println("Fazendo upload de objeto...")
-	_, err := client.UploadS3("teste", "teste1/exemplo-teste", "/home/angelo/Testes/exemplo.html", ctx)
+	_, err = client.UploadS3("teste", "teste", "exemplo.html", file, ctx)
 	if err != nil {
 		log.Printf("Erro ao fazer upload: %s", err.Error())
 	} else {

--- a/s3handler/upload.go
+++ b/s3handler/upload.go
@@ -3,42 +3,32 @@ package s3handler
 import (
 	"context"
 	"os"
-	"path/filepath"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
-// Upload faz upload do objeto para o bucket S3 (Objetos de até 5GB) e cria um bucket baseado no prefix se não existir.
-func (client *Client) UploadS3(bucketName, prefix, path string, ctx context.Context) (bool, error) {
+/* 
+Upload faz upload do objeto para o bucket S3 (Objetos de até 5GB) e cria um bucket baseado no prefix se não existir.
+O parâmetro prefix é opcional e pode ser uma string vazia.
+O prefixo não deve conter barras ("/") no início ou no final.
+*/
+func (client *Client) UploadS3(bucketName, prefix, filename string, file *os.File, ctx context.Context) (bool, error) {
 
-	if bucketName == "" || path == "" {
+	if bucketName == "" {
 		return false, &S3Error{
 			Operation: "upload",
 			Bucket:    bucketName,
-			Object:    path,
+			Object:    filename,
 			Message:   "ErrEmptyParam",
 			Err:       ErrEmptyParam,
 		}
 	}
 
-	filename := filepath.Base(path)
-
-	file, err := os.Open(path)
-	if err != nil {
-		return false, &S3Error{
-			Operation: "upload",
-			Bucket:    bucketName,
-			Object:    path,
-			Message:   "FileOpenError",
-			Err:       err,
-		}
-	}
-	defer file.Close()
-
 	key := filename
 	if prefix != "" {
-		key = prefix + "/" + filename
+
+		key = prefix + "/" + key
 	}
 
 	input := &s3.PutObjectInput{
@@ -47,7 +37,7 @@ func (client *Client) UploadS3(bucketName, prefix, path string, ctx context.Cont
 		Body:   file,
 	}
 
-	_, err = client.S3Client.PutObject(ctx, input)
+	_, err := client.S3Client.PutObject(ctx, input)
 	if err != nil {
 
 		parsedErr := ParseError(err)

--- a/tests/s3handler_tests/upload_test.go
+++ b/tests/s3handler_tests/upload_test.go
@@ -1,48 +1,61 @@
 package s3handler_test
 
 import (
-	"github.com/ADStefano/AmazonHandler/s3handler"
 	"context"
 	"errors"
+	"os"
 	"testing"
+
+	"github.com/ADStefano/AmazonHandler/s3handler"
 )
 
 type TestUpload struct {
+	TestName       string
 	TestBucketName string
 	Prefix         string
-	Path           string
+	Filename       string
+	File           *os.File
 	ExpectedOutput bool
 	ExpectedError  error
 }
 
+var mockFile *os.File
+
 var testUploadCases = []TestUpload{
 	{
+		TestName:       "Success - upload without prefix",
 		TestBucketName: "test",
 		Prefix:         "",
-		Path:           "/home/angelo/Documentos/Programação/exemplo.html",
+		Filename:       "exemplo.html",
+		File:           mockFile,
 		ExpectedOutput: true,
 		ExpectedError:  nil,
 	},
 	{
+		TestName:       "Success",
 		TestBucketName: "test",
 		Prefix:         "uploads",
-		Path:           "/home/angelo/Documentos/Programação/exemplo.html",
+		Filename:       "exemplo.html",
+		File:           mockFile,
 		ExpectedOutput: true,
 		ExpectedError:  nil,
 	},
 	{
+		TestName:       "Fail - Entity Too Large",
 		TestBucketName: "entity-too-large",
 		Prefix:         "uploads",
-		Path:           "/home/angelo/Documentos/Programação/exemplo.html",
+		Filename:       "exemplo.html",
+		File:           mockFile,
 		ExpectedOutput: false,
 		ExpectedError:  s3handler.ErrEntityTooLarge,
 	},
 }
 
 func TestUploads(t *testing.T) {
+
 	for _, testCase := range testUploadCases {
-		t.Run(testCase.Path, func(t *testing.T) {
-			output, err := mockClient.UploadS3(testCase.TestBucketName, testCase.Prefix, testCase.Path, context.Background())
+		t.Run(testCase.TestName, func(t *testing.T) {
+			output, err := mockClient.UploadS3(testCase.TestBucketName, testCase.Prefix, testCase.Filename, testCase.File, context.Background())
 
 			if output != testCase.ExpectedOutput {
 				t.Errorf("Output esperado %v, recebido %v", testCase.ExpectedOutput, output)


### PR DESCRIPTION
Não faz sentido passar o caminho para a função Upload, a função deve receber os dados sem precisar lidar com open/close do arquivo e ser responsável apenas por enviar para o bucket S3

fix #20 